### PR TITLE
Fix bug UndefinedFunctionError doesn't have a message field

### DIFF
--- a/lib/plug_checkup/check.ex
+++ b/lib/plug_checkup/check.ex
@@ -35,6 +35,6 @@ defmodule PlugCheckup.Check do
   def safe_execute(check) do
     apply(check.module, check.function, [])
   rescue
-    e -> {:error, e.message}
+    e -> {:error, Exception.message(e)}
   end
 end

--- a/test/plug_checkup/check_test.exs
+++ b/test/plug_checkup/check_test.exs
@@ -9,6 +9,11 @@ defmodule PlugCheckup.CheckTest do
       assert Check.safe_execute(check) == {:error, "Exception"}
     end
 
+    test "it converts exceptions without message field to errors" do
+      check = %Check{module: MyChecks, function: :non_existent_function}
+      assert Check.safe_execute(check) == {:error, "function MyChecks.non_existent_function/0 is undefined or private"}
+    end
+
     test "it doesn't change error results" do
       check = %Check{module: MyChecks, function: :execute_with_error}
       assert Check.safe_execute(check) == {:error, "Error"}


### PR DESCRIPTION
Fix #4 

Call the function `Exception.message/1` to determine the message of the
exception