### PR TITLE
Add function PlugCheckup.Options.new/1

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -23,13 +23,19 @@ defmodule MyRouter do
     %Check{name: "random1", module: Health.RandomCheck, function: :call},
     %Check{name: "random2", module: Health.RandomCheck, function: :call},
   ]
-  deps_checks = [
-    %Check{name: "random1", module: Health.RandomCheck, function: :call},
-    %Check{name: "random2", module: Health.RandomCheck, function: :call},
-  ]
+  forward(
+    "/selfhealth",
+    to: PlugCheckup,
+    init_opts: Options.new(checks: self_checks, timeout: 1000))
 
-  forward "/selfhealth", to: PlugCheckup, init_opts: %Options{checks: self_checks, timeout: 1000}
-  forward "/dependencyhealth", to: PlugCheckup, init_opts: %Options{checks: deps_checks, timeout: 1000}
+    deps_checks = [
+      %Check{name: "random1", module: Health.RandomCheck, function: :call},
+      %Check{name: "random2", module: Health.RandomCheck, function: :call},
+    ]
+    forward(
+    "/dependencyhealth",
+    to: PlugCheckup,
+    init_opts: Options.new(checks: deps_checks, timeout: 3000, pretty: false))
 
   match _ do
     send_resp(conn, 404, "oops")

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ checks = [
 forward(
   "/health",
   to: PlugCheckup,
-  init_opts: %PlugCheckup.Options{checks: checks}
+  init_opts: PlugCheckup.Options.new(checks: checks)
 )
 ```
 
@@ -55,7 +55,7 @@ checks = [
   %PlugCheckup.Check{name: "Redis", module: MyHealthChecks, function: :check_redis}
 ]
 
-forward("/health", PlugCheckup, %PlugCheckup.Options{checks: checks})
+forward("/health", PlugCheckup, PlugCheckup.Options.new(checks: checks))
 ```
 
 ## The Checks

--- a/lib/plug_checkup/options.ex
+++ b/lib/plug_checkup/options.ex
@@ -3,4 +3,57 @@ defmodule PlugCheckup.Options do
   Defines the options which can be given to initialize PlugCheckup.
   """
   defstruct timeout: :timer.seconds(1), checks: [], pretty: true
+
+  @type t ::  %__MODULE__{
+    timeout: pos_integer(),
+    checks: list(PlugCheckup.Check.t()),
+    pretty: boolean()
+  }
+
+  @spec new(keyword()) :: __MODULE__.t()
+  def new(opts \\ []) do
+    default = %__MODULE__{}
+    Map.merge(default, fields_to_change(opts))
+  end
+
+  defp fields_to_change(opts) do
+    opts
+    |> Keyword.take([:timeout, :checks, :pretty])
+    |> Enum.into(Map.new)
+    |> validate!()
+  end
+
+  defp validate!(fields) do
+    validate_change(fields, :timeout, &validate_timeout!/1)
+    validate_change(fields, :checks, &validate_checks!/1)
+    validate_change(fields, :pretty, &validate_pretty!/1)
+
+    fields
+  end
+
+  defp validate_change(fields, key, validator) do
+    if Map.has_key?(fields, key) do
+      value = fields[key]
+      validator.(value)
+    end
+  end
+
+  defp validate_timeout!(timeout) do
+    if !is_integer(timeout) || timeout <= 0 do
+      raise ArgumentError, message: "timeout should be a positive integer"
+    end
+  end
+
+  defp validate_checks!(checks) do
+    not_a_check? = &(!match?(%{__struct__: PlugCheckup.Check}, &1))
+    if Enum.any?(checks, not_a_check?) do
+      raise ArgumentError, message: "checks should be a list of PlugCheckup.Check"
+    end
+  end
+
+  defp validate_pretty!(pretty) do
+    if pretty not in [true, false] do
+      raise ArgumentError, message: "pretty should be a boolean"
+    end
+  end
 end

--- a/test/plug_checkup/options_test.exs
+++ b/test/plug_checkup/options_test.exs
@@ -3,18 +3,73 @@ defmodule PlugCheckup.OptionsTest do
 
   alias PlugCheckup.Options
 
-  test "it has default timeout" do
-    options = %Options{}
-    assert options.timeout == :timer.seconds(1)
+  describe "default values" do
+    test "it has default timeout" do
+      options = Options.new()
+      assert options.timeout == :timer.seconds(1)
+    end
+
+    test "it has default checks" do
+      options = Options.new()
+      assert options.checks == []
+    end
+
+    test "it has default pretty" do
+      options = Options.new()
+      assert options.pretty == true
+    end
   end
 
-  test "it has default checks" do
-    options = %Options{}
-    assert options.checks == []
+  describe "setting timeout" do
+    test "timeout is set for positive integers" do
+      options = Options.new(timeout: 12)
+      assert options.timeout == 12
+    end
+
+    test "it raises exception when timeout is zero" do
+      assert_raise(ArgumentError, "timeout should be a positive integer", fn ->
+        Options.new(timeout: 0)
+      end)
+    end
+
+    test "it raises exception when timeout is negative" do
+      assert_raise(ArgumentError, "timeout should be a positive integer", fn ->
+        Options.new(timeout: -1)
+      end)
+    end
+
+    test "it raises exception when timeout is not integer" do
+      assert_raise(ArgumentError, "timeout should be a positive integer", fn ->
+        Options.new(timeout: :atom)
+      end)
+    end
   end
 
-  test "it has default pretty" do
-    options = %Options{}
-    assert options.pretty
+  describe "setting checks" do
+    test "checks is set for a list of PlugCheckup.Check" do
+      check = %PlugCheckup.Check{name: "check 1"}
+      options = Options.new(checks: [check])
+      assert options.checks == [check]
+    end
+
+    test "it raises exception when checks is not a list of PlugCheckup.Check" do
+      assert_raise(ArgumentError, "checks should be a list of PlugCheckup.Check", fn ->
+        check = %{}
+        Options.new(checks: [check])
+      end)
+    end
+  end
+
+  describe "setting pretty" do
+    test "pretty is set for a boolean" do
+      options = Options.new(pretty: false)
+      assert options.pretty == false
+    end
+
+    test "it raises exception when pretty is not a boolean" do
+      assert_raise(ArgumentError, "pretty should be a boolean", fn ->
+        Options.new(pretty: :not_a_boolean)
+      end)
+    end
   end
 end

--- a/test/plug_checkup_test.exs
+++ b/test/plug_checkup_test.exs
@@ -17,7 +17,7 @@ defmodule PlugCheckupTest do
   end
 
   def execute_plug(check = %Check{}) do
-    options = PlugCheckup.init(%Options{checks: [check]})
+    options = PlugCheckup.init(Options.new(checks: [check]))
     request = conn(:get, "/")
 
     PlugCheckup.call(request, options)


### PR DESCRIPTION
Fix #14 

Add function `new` to build and validate the Options, this way the
application won't start if there are mismatching configuration for
PlugCheckup