### PR TITLE
Allow to select checks via a query parameter

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-elixir 1.9.4
-erlang 22.1.4

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ PlugCheckup should return either 200 or 500 statuses, Content-Type header "appli
 
 If you configure the `error_code` option when initializing the plug, the specified value will be used when an error occurs instead of the 500 status.
 
+When providing a check name in the query param `check_name_selector`, only checks matching the name will be executed.
+
 ## Demo
 
 Check [.iex.exs](.iex.exs) for a demo of plug_checkup in a Plug.Router. The demo can be run as following.

--- a/lib/plug_checkup.ex
+++ b/lib/plug_checkup.ex
@@ -14,7 +14,10 @@ defmodule PlugCheckup do
   end
 
   def call(conn, opts) do
-    results = Runner.async_run(opts.checks, opts.timeout)
+    conn = fetch_query_params(conn)
+
+    results =
+      Runner.async_run(opts.checks, opts.timeout, conn.query_params["check_name_selector"])
 
     conn
     |> put_resp_content_type("application/json")

--- a/lib/plug_checkup/check/runner.ex
+++ b/lib/plug_checkup/check/runner.ex
@@ -5,10 +5,12 @@ defmodule PlugCheckup.Check.Runner do
   """
   alias PlugCheckup.Check
 
-  @spec async_run([PlugCheckup.Check.t()], pos_integer()) :: tuple()
-  def async_run(checks, timeout) do
+  @spec async_run([PlugCheckup.Check.t()], pos_integer(), check_name_selector :: String.t() | nil) ::
+          tuple()
+  def async_run(checks, timeout, check_name_selector \\ nil) do
     results =
       checks
+      |> filter_by_check_selector(check_name_selector)
       |> execute_all(timeout)
       |> Enum.zip(checks)
       |> Enum.map(&task_to_result/1)
@@ -41,4 +43,10 @@ defmodule PlugCheckup.Check.Runner do
   def task_to_result({{:exit, reason}, check}) do
     %{check | result: {:error, reason}}
   end
+
+  defp filter_by_check_selector(checks, check_name_selector)
+  defp filter_by_check_selector(checks, nil), do: checks
+
+  defp filter_by_check_selector(checks, check_name_selector) when is_binary(check_name_selector),
+    do: Enum.filter(checks, &match?(%Check{name: ^check_name_selector}, &1))
 end

--- a/test/plug_checkup/check/runner_test.exs
+++ b/test/plug_checkup/check/runner_test.exs
@@ -53,7 +53,7 @@ defmodule PlugCheckup.Check.RunnerTest do
     end
   end
 
-  describe "async_run/2" do
+  describe "async_run/3" do
     test "it executes all checks and returns ok when all checks are successful" do
       checks = [
         %Check{name: "1", module: MyChecks, function: :execute_successfuly},
@@ -77,6 +77,24 @@ defmodule PlugCheckup.Check.RunnerTest do
                   time: _
                 }
               ]} = Runner.async_run(checks, 500)
+    end
+
+    test "it executes checks matching selector query arg" do
+      checks = [
+        %Check{name: "1", module: MyChecks, function: :execute_successfuly},
+        %Check{name: "2", module: MyChecks, function: :execute_successfuly}
+      ]
+
+      assert {:ok,
+              [
+                %Check{
+                  name: "1",
+                  module: MyChecks,
+                  function: :execute_successfuly,
+                  result: :ok,
+                  time: _
+                }
+              ]} = Runner.async_run(checks, 500, "1")
     end
 
     test "it executes all checks and returns error when any check is unsuccessful" do

--- a/test/plug_checkup_test.exs
+++ b/test/plug_checkup_test.exs
@@ -4,20 +4,27 @@ defmodule PlugCheckupTest do
 
   alias PlugCheckup.Check
   alias PlugCheckup.Options
+  alias Plug.Conn.Query
 
-  def execute_plug(:healthy) do
+  defp execute_plug(check, query_params \\ %{})
+
+  defp execute_plug(:healthy, query_params) do
     check = %Check{name: "1", module: MyChecks, function: :execute_successfuly}
-    execute_plug(check)
+    execute_plug(check, query_params)
   end
 
-  def execute_plug(:not_healthy) do
+  defp execute_plug(:not_healthy, query_params) do
     check = %Check{name: "1", module: MyChecks, function: :execute_with_error}
-    execute_plug(check)
+    execute_plug(check, query_params)
   end
 
-  def execute_plug(check = %Check{}) do
-    options = PlugCheckup.init(Options.new(json_encoder: Jason, checks: [check]))
-    request = conn(:get, "/")
+  defp execute_plug(check = %Check{}, query_params) do
+    execute_plug([check], query_params)
+  end
+
+  defp execute_plug(checks, query_params) when is_list(checks) do
+    options = PlugCheckup.init(Options.new(json_encoder: Jason, checks: checks))
+    request = conn(:get, "/?" <> Query.encode(query_params))
 
     PlugCheckup.call(request, options)
   end
@@ -25,6 +32,19 @@ defmodule PlugCheckupTest do
   describe "status" do
     test "it is 200 when healthy" do
       response = execute_plug(:healthy)
+      assert response.status == 200
+    end
+
+    test "filters checks by selector" do
+      response =
+        execute_plug(
+          [
+            %Check{name: "1", module: MyChecks, function: :execute_successfuly},
+            %Check{name: "2", module: MyChecks, function: :execute_with_error}
+          ],
+          %{"check_name_selector" => "1"}
+        )
+
       assert response.status == 200
     end
 


### PR DESCRIPTION
We're using UptimeRobot which unfortunately can't interpret multiple checks. Therefore we need to add multiple health check URLs. With this change, checks can be selected to run alone.