### PR TITLE
Resolve Compile Warning and raise Elixir Minimum Requirement to 1.10

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
       
     - name: Setup Elixir
-      uses: actions/setup-elixir@v1.5.0
+      uses: erlef/setup-beam@v1
       with:
         elixir-version: 1.9.4
         otp-version: 22.1.4
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
         
       - name: Setup elixir
-        uses: actions/setup-elixir@v1.5.0
+        uses: erlef/setup-beam@v1
         with:
           elixir-version: 1.9.4
           otp-version: 22.1.4

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -17,8 +17,8 @@ jobs:
     - name: Setup Elixir
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: 1.9.4
-        otp-version: 22.1.4
+        elixir-version: 1.12.0
+        otp-version: 24.0
         install-hex: false
         install-rebar: false
     
@@ -40,8 +40,8 @@ jobs:
       - name: Setup elixir
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: 1.9.4
-          otp-version: 22.1.4
+          elixir-version: 1.12.0
+          otp-version: 24.0
 
       - name: Install Dependencies
         run: |

--- a/lib/plug_checkup/options.ex
+++ b/lib/plug_checkup/options.ex
@@ -93,16 +93,19 @@ defmodule PlugCheckup.Options do
   end
 
   defp validate_json_encoder!(encoder) do
-    unless Code.ensure_compiled?(encoder) do
-      raise ArgumentError,
-            "invalid :json_encoder option. The module #{inspect(encoder)} is not " <>
-              "loaded and could not be found"
-    end
+    with {:module, _module} <- Code.ensure_compiled(encoder),
+         true <- function_exported?(encoder, :encode!, 2) do
+      :ok
+    else
+      {:error, _reason} ->
+        raise ArgumentError,
+              "invalid :json_encoder option. The module #{inspect(encoder)} is not " <>
+                "loaded and could not be found"
 
-    unless function_exported?(encoder, :encode!, 2) do
-      raise ArgumentError,
-            "invalid :json_encoder option. The module #{inspect(encoder)} must " <>
-              "implement encode!/2"
+      false ->
+        raise ArgumentError,
+              "invalid :json_encoder option. The module #{inspect(encoder)} must " <>
+                "implement encode!/2"
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule PlugCheckup.Mixfile do
     [
       app: :plug_checkup,
       version: "0.6.0",
-      elixir: "~> 1.5",
+      elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       description: description(),


### PR DESCRIPTION
Resolves the following compile warning:

```
warning: Code.ensure_compiled?/1 is deprecated. Use Code.ensure_compiled/1 instead (see the proper disclaimers in its docs)
  lib/plug_checkup/options.ex:96: PlugCheckup.Options.validate_json_encoder!/1
```

Since the function `Code.ensure_compiled/1` is only available since Elixir 1.10, I raised the minimum requirement.

If you prefer, we could also detect the Elixir Version and leave the old code in place for older versions.

Based on #72, merge that first.